### PR TITLE
Update regex to proper match a function name.

### DIFF
--- a/plugin/phpclassexplorer.vim
+++ b/plugin/phpclassexplorer.vim
@@ -6,7 +6,7 @@ let g:loaded_phpclassexplorer_plugin = 1
 function! s:findFunctions()
     let currentfile = expand("%")
     if filereadable(currentfile)
-        execute 'lvimgrep /on .*(/ '. currentfile
+        execute 'lvimgrep /function [a-zA-Z0-9]*(/ '. currentfile
     endif
 endfun
 


### PR DESCRIPTION
The previous regex could match strings that were not
actually a function.
